### PR TITLE
Publish landmark orientation & camera params

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ catkin_init_workspace
 cd src
 git clone https://github.com/shineyruan/cad2cav_onboard.git
 git clone https://github.com/f1tenth/f1tenth_system.git
+git clone --recursive https://github.com/shineyruan/cad2cav_common.git
 cd ..
 ```
 

--- a/object_detection/CMakeLists.txt
+++ b/object_detection/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(catkin REQUIRED COMPONENTS
   image_transport
   sensor_msgs
   cartographer_ros_msgs
+  cad2cav_msgs
 )
 
 ## System dependencies are found with CMake's conventions
@@ -123,7 +124,7 @@ endif()
 catkin_package(
  INCLUDE_DIRS include
  LIBRARIES video_loader object_detector
- CATKIN_DEPENDS roscpp roslib cv_bridge image_transport sensor_msgs cartographer_ros_msgs
+ CATKIN_DEPENDS roscpp roslib cv_bridge image_transport sensor_msgs cartographer_ros_msgs cad2cav_msgs
 #  DEPENDS system_lib
 )
 

--- a/object_detection/CMakeLists.txt
+++ b/object_detection/CMakeLists.txt
@@ -21,11 +21,13 @@ find_package(catkin REQUIRED COMPONENTS
   sensor_msgs
   cartographer_ros_msgs
   cad2cav_msgs
+  cad2cav_types
 )
 
 ## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS program_options)
 find_package(OpenCV 4 REQUIRED)
+find_package(Eigen3 REQUIRED)
 
 find_package(CUDA)
 if (CUDA_FOUND)
@@ -124,7 +126,7 @@ endif()
 catkin_package(
  INCLUDE_DIRS include
  LIBRARIES video_loader object_detector
- CATKIN_DEPENDS roscpp roslib cv_bridge image_transport sensor_msgs cartographer_ros_msgs cad2cav_msgs
+ CATKIN_DEPENDS roscpp roslib cv_bridge image_transport sensor_msgs cartographer_ros_msgs cad2cav_msgs cad2cav_types
 #  DEPENDS system_lib
 )
 
@@ -145,6 +147,7 @@ include_directories(
   ${catkin_INCLUDE_DIRS}
   ${OpenCV_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIR}
+  ${EIGEN3_INCLUDE_DIR}
 )
 
 ## Declare a C++ library
@@ -284,6 +287,13 @@ install(TARGETS
 ## Mark cpp header files for installation
 install(DIRECTORY include/${PROJECT_NAME}/
   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
+  FILES_MATCHING 
+  PATTERN "*.h"
+  PATTERN "*.hpp"
+  PATTERN ".svn" EXCLUDE
+)
+install(DIRECTORY include/apriltag-3.1.4/
+  DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/apriltag-3.1.4
   FILES_MATCHING 
   PATTERN "*.h"
   PATTERN "*.hpp"

--- a/object_detection/include/object_detection/apriltag_detector.hpp
+++ b/object_detection/include/object_detection/apriltag_detector.hpp
@@ -14,6 +14,8 @@
  * @date 2021-07-12
  */
 
+#include <Eigen/Dense>
+
 #include "object_detection/apriltag.hpp"
 
 namespace object_detection {
@@ -23,9 +25,9 @@ public:
   AprilTagDetector(apriltag::TagType tag_type, double tag_size, double fx,
                    double fy, double cx, double cy);
   AprilTagDetector(apriltag::TagType tag_type, double tag_size,
-                   const cv::Mat& intrinsic_mtx);
+                   const Eigen::Matrix3d& intrinsic_mtx);
   AprilTagDetector(const std::string tag_type_str, double tag_size,
-                   const cv::Mat& intrinsic_mtx);
+                   const Eigen::Matrix3d& intrinsic_mtx);
   ~AprilTagDetector();
 
   std::vector<apriltag::TagInfo> detect(const cv::Mat& frame) const;
@@ -52,9 +54,9 @@ private:
    * frame).
    *
    * @param pt
-   * @return cv::Vec3f
+   * @return Eigen::Vector3f
    */
-  static cv::Vec3f toBaseLinkFrame(const cv::Vec3f& pt);
+  static Eigen::Vector3f toBaseLinkFrame(const Eigen::Vector3f& pt);
 };
 
 }  // namespace object_detection

--- a/object_detection/include/object_detection/landmark_processor.hpp
+++ b/object_detection/include/object_detection/landmark_processor.hpp
@@ -44,8 +44,6 @@ public:
   void publishLandmark(const std::vector<apriltag::TagInfo>& tag_list,
                        const ros::Time& msg_stamp) const;
 
-  std::vector<cv::Point3f> deproject(const std::vector<BoundingBox>& bbox_list);
-
   void imageReceiveCallback(const sensor_msgs::ImageConstPtr& msg);
 
 private:

--- a/object_detection/include/object_detection/landmark_processor.hpp
+++ b/object_detection/include/object_detection/landmark_processor.hpp
@@ -6,13 +6,17 @@
 #include <ros/package.h>
 #include <sensor_msgs/image_encodings.h>
 
+#include <Eigen/Dense>
+#include <boost/filesystem.hpp>
 #include <memory>
-#include <opencv2/core/utils/filesystem.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#include "cad2cav_types/camera.hpp"
 #include "cartographer_ros_msgs/LandmarkList.h"
 #include "object_detection/apriltag_detector.hpp"
 #include "object_detection/object_detector.hpp"
+
+namespace fs = boost::filesystem;
 
 namespace object_detection {
 
@@ -26,7 +30,7 @@ public:
                     double tag_size        = 0.01495);
   LandmarkProcessor(const std::string model_path, const std::string config_path,
                     DNNType dnn_type, DatasetType dataset_type,
-                    cv::String camera_calibration_params_path,
+                    std::string camera_calibration_params_path,
                     std::string tag_family = "TagStandard41h12",
                     double tag_size        = 0.01495);
 
@@ -47,24 +51,25 @@ public:
   void imageReceiveCallback(const sensor_msgs::ImageConstPtr& msg);
 
 private:
-  const cv::String PACKAGE_DIR = ros::package::getPath("object_detection");
-  const cv::String DEFAULT_MODEL_PATH = cv::utils::fs::join(
-                       PACKAGE_DIR, "models/yolov4-tiny.weights"),
-                   DEFAULT_CONFIG_PATH = cv::utils::fs::join(
-                       PACKAGE_DIR, "models/yolov4-tiny.cfg");
-  const cv::String DEFAULT_CAM_PARAM_PATH =
-      cv::utils::fs::join(PACKAGE_DIR, "params/camera/params.xml");
+  const std::string PACKAGE_DIR = ros::package::getPath("object_detection");
+  const std::string
+      DEFAULT_MODEL_PATH =
+          (fs::path(PACKAGE_DIR) / "models/yolov4-tiny.weights").string(),
+      DEFAULT_CONFIG_PATH =
+          (fs::path(PACKAGE_DIR) / "models/yolov4-tiny.cfg").string();
+  const std::string DEFAULT_CAM_PARAM_PATH =
+      (fs::path(PACKAGE_DIR) / "params/camera/params.xml").string();
 
   ros::NodeHandle n_;
   image_transport::ImageTransport it_;
   image_transport::Subscriber img_sub_;
   ros::Publisher landmark_pub_;
 
-  cv::String camera_params_path_;
-  cv::Mat camera_intrinsic_;
-  cv::Mat camera_distortion_coeff_;
-  cv::Mat camera_extrinsic_rot_;
-  cv::Mat camera_extrinsic_trans_;
+  std::string camera_params_path_;
+  Eigen::Matrix3d camera_intrinsic_;
+  Eigen::RowVectorXd camera_distortion_coeff_;
+  Eigen::Matrix3d camera_extrinsic_rot_;
+  Eigen::Vector3d camera_extrinsic_trans_;
 
   cv::Mat current_frame_;
   std::unique_ptr<ObjectDetector> object_detector_;

--- a/object_detection/include/object_detection/landmark_processor.hpp
+++ b/object_detection/include/object_detection/landmark_processor.hpp
@@ -11,6 +11,7 @@
 #include <memory>
 #include <opencv2/highgui/highgui.hpp>
 
+#include "cad2cav_msgs/LandmarkDetectionList.h"
 #include "cad2cav_types/camera.hpp"
 #include "cartographer_ros_msgs/LandmarkList.h"
 #include "object_detection/apriltag_detector.hpp"
@@ -47,6 +48,9 @@ public:
                        const ros::Time& msg_stamp) const;
   void publishLandmark(const std::vector<apriltag::TagInfo>& tag_list,
                        const ros::Time& msg_stamp) const;
+  void publishLandmarkToCartographer(
+      const std::vector<apriltag::TagInfo>& tag_list,
+      const ros::Time& msg_stamp) const;
 
   void imageReceiveCallback(const sensor_msgs::ImageConstPtr& msg);
 
@@ -66,10 +70,7 @@ private:
   ros::Publisher landmark_pub_;
 
   std::string camera_params_path_;
-  Eigen::Matrix3d camera_intrinsic_;
-  Eigen::RowVectorXd camera_distortion_coeff_;
-  Eigen::Matrix3d camera_extrinsic_rot_;
-  Eigen::Vector3d camera_extrinsic_trans_;
+  cad2cav::Camera camera_;
 
   cv::Mat current_frame_;
   std::unique_ptr<ObjectDetector> object_detector_;

--- a/object_detection/package.xml
+++ b/object_detection/package.xml
@@ -56,6 +56,7 @@
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
   <build_depend>cad2cav_msgs</build_depend>
+  <build_depend>cad2cav_types</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>roslib</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
@@ -63,6 +64,7 @@
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>image_transport</build_export_depend>
   <build_export_depend>cad2cav_msgs</build_export_depend>
+  <build_export_depend>cad2cav_types</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>roslib</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
@@ -70,6 +72,7 @@
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>image_transport</exec_depend>
   <exec_depend>cad2cav_msgs</exec_depend>
+  <exec_depend>cad2cav_types</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/object_detection/package.xml
+++ b/object_detection/package.xml
@@ -55,18 +55,21 @@
   <build_depend>cartographer_ros_msgs</build_depend>
   <build_depend>cv_bridge</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>cad2cav_msgs</build_depend>
   <build_export_depend>roscpp</build_export_depend>
   <build_export_depend>roslib</build_export_depend>
   <build_export_depend>sensor_msgs</build_export_depend>
   <build_export_depend>cartographer_ros_msgs</build_export_depend>
   <build_export_depend>cv_bridge</build_export_depend>
   <build_export_depend>image_transport</build_export_depend>
+  <build_export_depend>cad2cav_msgs</build_export_depend>
   <exec_depend>roscpp</exec_depend>
   <exec_depend>roslib</exec_depend>
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>cartographer_ros_msgs</exec_depend>
   <exec_depend>cv_bridge</exec_depend>
   <exec_depend>image_transport</exec_depend>
+  <exec_depend>cad2cav_msgs</exec_depend>
 
 
   <!-- The export tag contains other, unspecified, tags -->

--- a/object_detection/src/landmark_processor.cpp
+++ b/object_detection/src/landmark_processor.cpp
@@ -23,6 +23,7 @@ LandmarkProcessor::LandmarkProcessor(const std::string model_path,
     : n_(ros::NodeHandle()),
       it_(n_),
       camera_params_path_(camera_calibration_params_path),
+      camera_distortion_coeff_(5),
       current_frame_() {
   object_detector_ = std::make_unique<ObjectDetector>(
       model_path, dnn_type, dataset_type, config_path);
@@ -35,6 +36,7 @@ LandmarkProcessor::LandmarkProcessor(std::string tag_family, double tag_size)
     : n_(ros::NodeHandle()),
       it_(n_),
       camera_params_path_(DEFAULT_CAM_PARAM_PATH),
+      camera_distortion_coeff_(5),
       current_frame_() {
   object_detector_ =
       std::make_unique<ObjectDetector>(DEFAULT_MODEL_PATH, DNNType::DARKNET,
@@ -51,6 +53,7 @@ LandmarkProcessor::LandmarkProcessor(const std::string model_path,
     : n_(ros::NodeHandle()),
       it_(n_),
       camera_params_path_(DEFAULT_CAM_PARAM_PATH),
+      camera_distortion_coeff_(5),
       current_frame_() {
   object_detector_ = std::make_unique<ObjectDetector>(
       model_path, dnn_type, dataset_type, config_path);
@@ -93,12 +96,15 @@ void LandmarkProcessor::publishLandmark(
     landmark.tracking_from_landmark_transform.position.x = tag_list[i].pos[0];
     landmark.tracking_from_landmark_transform.position.y = tag_list[i].pos[1];
     landmark.tracking_from_landmark_transform.position.z = tag_list[i].pos[2];
+    Eigen::Quaternionf quat_orientation{tag_list[i].rot};
     landmark.tracking_from_landmark_transform.orientation.x =
-        tag_list[i].rot[0];
+        quat_orientation.x();
     landmark.tracking_from_landmark_transform.orientation.y =
-        tag_list[i].rot[1];
+        quat_orientation.y();
     landmark.tracking_from_landmark_transform.orientation.z =
-        tag_list[i].rot[2];
+        quat_orientation.z();
+    landmark.tracking_from_landmark_transform.orientation.w =
+        quat_orientation.w();
     landmark.rotation_weight    = 1e6;
     landmark.translation_weight = 1e6;
     landmark_list.landmarks.emplace_back(landmark);
@@ -139,18 +145,29 @@ void LandmarkProcessor::initCameraParams() {
     throw ros::Exception("camera param read error");
   }
 
-  file["intrinsic"] >> camera_intrinsic_;
+  cv::Mat camera_intrinsic, camera_distortion_coeff, camera_extrinsic_rot,
+      camera_extrinsic_trans;
+  file["intrinsic"] >> camera_intrinsic;
+  camera_intrinsic_ = Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+      camera_intrinsic.ptr<double>());
   ROS_INFO_STREAM("Loaded camera intrinsic:\n" << camera_intrinsic_ << "\n");
 
-  file["distortion"] >> camera_distortion_coeff_;
+  file["distortion"] >> camera_distortion_coeff;
+  camera_distortion_coeff_ =
+      Eigen::Map<Eigen::RowVectorXd>(camera_distortion_coeff.ptr<double>(), 5);
   ROS_INFO_STREAM("Loaded camera distortion:\n"
                   << camera_distortion_coeff_ << "\n");
 
-  file["rotation"] >> camera_extrinsic_rot_;
+  file["rotation"] >> camera_extrinsic_rot;
+  camera_extrinsic_rot_ =
+      Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+          camera_extrinsic_rot.ptr<double>());
   ROS_INFO_STREAM("Loaded camera extrinsic rotation matrix:\n"
                   << camera_extrinsic_rot_ << "\n");
 
-  file["translation"] >> camera_extrinsic_trans_;
+  file["translation"] >> camera_extrinsic_trans;
+  camera_extrinsic_trans_ =
+      Eigen::Map<Eigen::Vector3d>(camera_extrinsic_trans.ptr<double>());
   ROS_INFO_STREAM("Loaded camera extrinsic translation matrix:\n"
                   << camera_extrinsic_trans_ << "\n");
 }

--- a/object_detection/src/landmark_processor.cpp
+++ b/object_detection/src/landmark_processor.cpp
@@ -8,8 +8,8 @@ void LandmarkProcessor::init() {
   ROS_WARN("Listening to topic /camera/image_raw for landmark processing...");
 
   landmark_pub_ =
-      n_.advertise<cartographer_ros_msgs::LandmarkList>("landmark", 1);
-  ROS_INFO("Landmarks published to topic /landmark");
+      n_.advertise<cad2cav_msgs::LandmarkDetectionList>("/cad2cav/landmark", 1);
+  ROS_INFO("Landmarks published to topic /cad2cav/landmark");
 
   initCameraParams();
   ROS_INFO("Camera params initialized");

--- a/object_detection/src/landmark_processor.cpp
+++ b/object_detection/src/landmark_processor.cpp
@@ -107,15 +107,6 @@ void LandmarkProcessor::publishLandmark(
   landmark_pub_.publish(landmark_list);
 }
 
-std::vector<cv::Point3f> LandmarkProcessor::deproject(
-    const std::vector<BoundingBox>& bbox_list) {
-  std::vector<cv::Point3f> object_list;
-
-  // TODO
-
-  return object_list;
-}
-
 void LandmarkProcessor::imageReceiveCallback(
     const sensor_msgs::ImageConstPtr& msg) {
   cv::Mat frame;

--- a/object_detection/src/landmark_processor.cpp
+++ b/object_detection/src/landmark_processor.cpp
@@ -23,27 +23,25 @@ LandmarkProcessor::LandmarkProcessor(const std::string model_path,
     : n_(ros::NodeHandle()),
       it_(n_),
       camera_params_path_(camera_calibration_params_path),
-      camera_distortion_coeff_(5),
       current_frame_() {
   object_detector_ = std::make_unique<ObjectDetector>(
       model_path, dnn_type, dataset_type, config_path);
   init();
-  apriltag_detector_ = std::make_unique<AprilTagDetector>(tag_family, tag_size,
-                                                          camera_intrinsic_);
+  apriltag_detector_ = std::make_unique<AprilTagDetector>(
+      tag_family, tag_size, camera_.getInfo().intrinsic_);
 }
 
 LandmarkProcessor::LandmarkProcessor(std::string tag_family, double tag_size)
     : n_(ros::NodeHandle()),
       it_(n_),
       camera_params_path_(DEFAULT_CAM_PARAM_PATH),
-      camera_distortion_coeff_(5),
       current_frame_() {
   object_detector_ =
       std::make_unique<ObjectDetector>(DEFAULT_MODEL_PATH, DNNType::DARKNET,
                                        DatasetType::COCO, DEFAULT_CONFIG_PATH);
   init();
-  apriltag_detector_ = std::make_unique<AprilTagDetector>(tag_family, tag_size,
-                                                          camera_intrinsic_);
+  apriltag_detector_ = std::make_unique<AprilTagDetector>(
+      tag_family, tag_size, camera_.getInfo().intrinsic_);
 }
 
 LandmarkProcessor::LandmarkProcessor(const std::string model_path,
@@ -53,13 +51,12 @@ LandmarkProcessor::LandmarkProcessor(const std::string model_path,
     : n_(ros::NodeHandle()),
       it_(n_),
       camera_params_path_(DEFAULT_CAM_PARAM_PATH),
-      camera_distortion_coeff_(5),
       current_frame_() {
   object_detector_ = std::make_unique<ObjectDetector>(
       model_path, dnn_type, dataset_type, config_path);
   init();
-  apriltag_detector_ = std::make_unique<AprilTagDetector>(tag_family, tag_size,
-                                                          camera_intrinsic_);
+  apriltag_detector_ = std::make_unique<AprilTagDetector>(
+      tag_family, tag_size, camera_.getInfo().intrinsic_);
 }
 
 void LandmarkProcessor::publishLandmark(
@@ -84,6 +81,33 @@ void LandmarkProcessor::publishLandmark(
 }
 
 void LandmarkProcessor::publishLandmark(
+    const std::vector<apriltag::TagInfo>& tag_list,
+    const ros::Time& msg_stamp) const {
+  cad2cav_msgs::LandmarkDetectionList landmark_list;
+  landmark_list.header.stamp    = msg_stamp;
+  landmark_list.header.frame_id = "base_link";
+
+  cad2cav_msgs::LandmarkDetection landmark_detection;
+  landmark_detection.camera_param = camera_.toMsg();
+  for (size_t i = 0; i < tag_list.size(); ++i) {
+    cad2cav_msgs::LandmarkEntry landmark;
+    landmark.id                            = std::to_string(tag_list[i].id);
+    landmark.pose_in_body_frame.position.x = tag_list[i].pos[0];
+    landmark.pose_in_body_frame.position.y = tag_list[i].pos[1];
+    landmark.pose_in_body_frame.position.z = tag_list[i].pos[2];
+    Eigen::Quaternionf quat_orientation{tag_list[i].rot};
+    landmark.pose_in_body_frame.orientation.x = quat_orientation.x();
+    landmark.pose_in_body_frame.orientation.y = quat_orientation.y();
+    landmark.pose_in_body_frame.orientation.z = quat_orientation.z();
+    landmark.pose_in_body_frame.orientation.w = quat_orientation.w();
+    landmark_detection.landmark_list.push_back(std::move(landmark));
+  }
+
+  landmark_list.landmark_detections.push_back(std::move(landmark_detection));
+  landmark_pub_.publish(landmark_list);
+}
+
+void LandmarkProcessor::publishLandmarkToCartographer(
     const std::vector<apriltag::TagInfo>& tag_list,
     const ros::Time& msg_stamp) const {
   cartographer_ros_msgs::LandmarkList landmark_list;
@@ -145,31 +169,43 @@ void LandmarkProcessor::initCameraParams() {
     throw ros::Exception("camera param read error");
   }
 
+  cad2cav::CameraInfo camera_info;
+
   cv::Mat camera_intrinsic, camera_distortion_coeff, camera_extrinsic_rot,
       camera_extrinsic_trans;
   file["intrinsic"] >> camera_intrinsic;
-  camera_intrinsic_ = Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
-      camera_intrinsic.ptr<double>());
-  ROS_INFO_STREAM("Loaded camera intrinsic:\n" << camera_intrinsic_ << "\n");
+  camera_info.intrinsic_ =
+      Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
+          camera_intrinsic.ptr<double>());
+  ROS_INFO_STREAM("Loaded camera intrinsic:\n"
+                  << camera_info.intrinsic_ << "\n");
 
   file["distortion"] >> camera_distortion_coeff;
-  camera_distortion_coeff_ =
+  Eigen::RowVectorXd eigen_camera_distortion_coeff{5};
+  eigen_camera_distortion_coeff =
       Eigen::Map<Eigen::RowVectorXd>(camera_distortion_coeff.ptr<double>(), 5);
   ROS_INFO_STREAM("Loaded camera distortion:\n"
-                  << camera_distortion_coeff_ << "\n");
+                  << eigen_camera_distortion_coeff << "\n");
+  for (size_t i = 0; i < camera_info.distortion_coeff_.size(); ++i) {
+    camera_info.distortion_coeff_.at(i) = eigen_camera_distortion_coeff[i];
+  }
 
   file["rotation"] >> camera_extrinsic_rot;
-  camera_extrinsic_rot_ =
+  Eigen::Matrix3d eigen_camera_extrinsic_rot =
       Eigen::Map<Eigen::Matrix<double, 3, 3, Eigen::RowMajor>>(
           camera_extrinsic_rot.ptr<double>());
-  ROS_INFO_STREAM("Loaded camera extrinsic rotation matrix:\n"
-                  << camera_extrinsic_rot_ << "\n");
 
   file["translation"] >> camera_extrinsic_trans;
-  camera_extrinsic_trans_ =
+  Eigen::Vector3d eigen_camera_extrinsic_trans =
       Eigen::Map<Eigen::Vector3d>(camera_extrinsic_trans.ptr<double>());
-  ROS_INFO_STREAM("Loaded camera extrinsic translation matrix:\n"
-                  << camera_extrinsic_trans_ << "\n");
+
+  camera_info.extrinsic_.block<3, 3>(0, 0) = eigen_camera_extrinsic_rot;
+  camera_info.extrinsic_.block<3, 1>(0, 3) = eigen_camera_extrinsic_trans;
+
+  ROS_INFO_STREAM("Loaded camera extrinsic matrix:\n"
+                  << camera_info.extrinsic_ << "\n");
+
+  camera_.setInfo(camera_info);
 }
 
 }  // namespace object_detection


### PR DESCRIPTION
This PR address multiple fixes and API changes:
1. **Add `cad2cav_common` repo dependency for workspace building**.
2. Switch OpenCV linear algebra usage to Eigen. OpenCV is now only for camera interfacing and object detection.
2. Add `camera` object in `LandmarkProcessor` to store intrinsic/extrinsic information.
3. Publish landmark topic to new msg topic in new msg type; integrate camera params into the topic.